### PR TITLE
Bug Fixes - Blade Master images and missing tooltip data for active vibe phrases

### DIFF
--- a/src/Components/Hit.tsx
+++ b/src/Components/Hit.tsx
@@ -39,7 +39,7 @@ export const Hit = ({
                         <Text>{trackIndexToText[enemy.x]} Track</Text>
                         <Text>Beat - {enemyBeat}</Text>
                         <Text>Health - {enemy.health} / {enemy.maxHealth}</Text>
-                        {enemy.isVibePhraseEnemyk &&
+                        {enemy.isVibePhraseEnemy &&
                             <Text>Active Vibe Phrase</Text>
                         }
                     </Stack>

--- a/src/data/EnemyData.json
+++ b/src/data/EnemyData.json
@@ -97,17 +97,17 @@
     "929": {
         "name": "Blademaster",
         "id": 929,
-        "image": "./data/Enemies/RedBladeMaster/base.png"
+        "image": "./data/Enemies/RedBlademaster/base.png"
     },
     "3685": {
         "name": "BlueBlademaster",
         "id": 3685,
-        "image": "./data/Enemies/BlueBladeMaster/base.png"
+        "image": "./data/Enemies/BlueBlademaster/base.png"
     },
     "7288": {
         "name": "YellowBlademaster",
         "id": 7288,
-        "image": "./data/Enemies/YellowBladeMaster/base.png"
+        "image": "./data/Enemies/YellowBlademaster/base.png"
     },
     "4601": {
         "name": "WhiteSkull",


### PR DESCRIPTION
* Fix #14 
* Fix issue where active vibe phrases were not showing that fact in the tooltip